### PR TITLE
Updated base image to latest version with jupyterlab 3.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-434b10ab
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:v1.5.0
 
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \


### PR DESCRIPTION
### Updates
- [x] Updated base image to the [latest version](https://gallery.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter) that uses `jupyterlab 3.0.16`
- [x] Tested locally to ensure that jupyterlab works
- [x] Tested locally to ensure packages from `requirements.txt` can be imported (e.g. `pandas` and `numpy`)
- [x] Pushed to Dockerhub: `melioconsulting/jupyterlab-kubeflow:jupyterlab-3.0.16`